### PR TITLE
Add Monstercat DLC to leaderboard

### DIFF
--- a/leaderboard/board_list.json
+++ b/leaderboard/board_list.json
@@ -67,6 +67,11 @@
 		"DLCEggplant02",
 		"DLCEggplant03",
 		"DLCEggplant04",
-		"DLCEggplant05"
+		"DLCEggplant05",
+		"DLCMango01",
+		"DLCMango02",
+		"DLCMango03",
+		"DLCMango04",
+		"DLCMango05"
 	]
 }

--- a/leaderboard/rotn.js
+++ b/leaderboard/rotn.js
@@ -89,6 +89,11 @@ var all_charts = {
 	"DLCEggplant03":{ "name": "Revenge"},
 	"DLCEggplant04":{ "name": "Why Oh You Are LOVE"},
 	"DLCEggplant05":{ "name": "Powers Of Destruction"},
+	"DLCMango01":{ "name": "Final Boss"},
+	"DLCMango02":{ "name": "New Game"},
+	"DLCMango03":{ "name": "Crab Rave"},
+	"DLCMango04":{ "name": "PLAY"},
+	"DLCMango05":{ "name": "Waiting For You"}
 }
 
 var custom_name_styles = {


### PR DESCRIPTION
Adds Mango tracks to `leaderboard/board_list.json` and `leaderboard/rotn.js` with their English names.