### PR TITLE
Add cheat blacklist

### DIFF
--- a/leaderboard/rotn.js
+++ b/leaderboard/rotn.js
@@ -111,6 +111,10 @@ var cheat_false_flags = {
 "475971a0-96ec-4686-b2c0-3884119c00a3": "true",
 }
 
+var cheat_blacklist = {
+"594a4463-222c-4991-a55f-b4315b42c574": "true",
+}
+
 function formatted_player_name( player_id, player_name ){
 	pname = document.createElement("span")
 	if( player_name.startsWith( "<color=#187ea8>[DEV] </color>" ) ){
@@ -259,6 +263,9 @@ function friendly_lb( lb_name ){
 function cheat_detect( score ){
 	if( cheat_false_flags.hasOwnProperty(score.player_id) ){
 	return false
+	}
+	if( cheat_blacklist.hasOwnProperty(score.player_id) ){
+	return true
 	}
 	if( score.cheated ){ 
 		console.log("python cheat detect")


### PR DESCRIPTION
Adds a blacklist in `rotn.js` which can be used to automatically flag certain users' scores as cheated.