### PR TITLE
Add OG DLC 2 to leaderboard

### DIFF
--- a/leaderboard/board_list.json
+++ b/leaderboard/board_list.json
@@ -86,7 +86,7 @@
 		"DLCStrawberry04",
 		"DLCStrawberry05",
 		"DLCStrawberry06",
-		"OG04",
-		"OG09",
+		"DLCOG04",
+		"DLCOG09",
 	]
 }

--- a/leaderboard/board_list.json
+++ b/leaderboard/board_list.json
@@ -86,5 +86,7 @@
 		"DLCStrawberry04",
 		"DLCStrawberry05",
 		"DLCStrawberry06",
+		"OG04",
+		"OG09",
 	]
 }

--- a/leaderboard/rotn.js
+++ b/leaderboard/rotn.js
@@ -111,6 +111,8 @@ var all_charts = {
 	"DLCStrawberry04":{ "name": "Darnell"},
 	"DLCStrawberry05":{ "name": "Ugh"},
 	"DLCStrawberry06":{ "name": "Senpai"},
+	"DLCOG04":{ "name": "Portabellohead"},
+ 	"DLCOG09":{ "name": "March of the Profane"},
 }
 
 var custom_name_styles = {


### PR DESCRIPTION
Adds OG tracks to `leaderboard/board_list.json` and `leaderboard/rotn.js` with their English names.